### PR TITLE
Add base64 as dependency

### DIFF
--- a/firecrawl.gemspec
+++ b/firecrawl.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do | spec |
   spec.files            = Dir[ "lib/**/*.rb", "LICENSE", "README.md", "firecrawl.gemspec" ]
   spec.require_paths    = [ "lib" ]
 
+  spec.add_runtime_dependency 'base64'
   spec.add_runtime_dependency 'faraday', '~> 2.7'
   spec.add_runtime_dependency 'dynamicschema', '~> 1.0.0.beta04'
 


### PR DESCRIPTION
`base64` will be removed from the standard library. 

I see this warning when I install the gem in Ruby 3.3:
```
base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of firecrawl to add base64 into its gemspec.
```

This PR adds` base64` as a dependency.